### PR TITLE
modified setup.py. now flash-swin-attention can be installed on Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import platform
 
 setup(
     name='flash_swin_attn',
@@ -7,8 +8,9 @@ setup(
     install_requires=[
         'torch',
         'einops',
-        'triton'
+        'triton-windows' if platform.system() == 'Windows' else 'triton'
     ],
+
     entry_points={
         'console_scripts': [
             # Add command line scripts here


### PR DESCRIPTION
Currently, Triton officially supports only Linux and does not support Windows. However, there is unofficial Windows support via [triton-windows](https://github.com/woct0rdho/triton-windows). Therefore, to make your flash-swin-attention work on Windows, you should configure install_requires to use triton-windows on Windows and triton on Linux. (I tested installation on Windows 10, and it installed successfully.)